### PR TITLE
Feature/status messages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
   ],
   "license": "MIT",
   "require": {
-    "php": "^7.3 || ^7.4 || ^8.0"
+    "php": "^7.3 || ^7.4 || ^8.0",
+    "ext-mbstring": "*"
   },
   "require-dev": {
     "nunomaduro/collision": "^4.2",

--- a/src/Snake/Contracts/SpinnerInterface.php
+++ b/src/Snake/Contracts/SpinnerInterface.php
@@ -24,4 +24,12 @@ interface SpinnerInterface
      * Switch to STDOUT instead of STDERR
      */
     public function useStdOut(): void;
+
+    /**
+     * Set a status message to be displayed along the spinner.
+     * Set to null to show no status message.
+     *
+     * @param string|null $message
+     */
+    public function setMessage(?string $message): void;
 }

--- a/src/Snake/Spinner.php
+++ b/src/Snake/Spinner.php
@@ -172,6 +172,7 @@ class Spinner implements SpinnerInterface
     {
         if ($message === null) {
             $this->message = null;
+            return;
         }
 
         $message = mb_substr($message, 0, $this->terminalCols-10);

--- a/src/Snake/Spinner.php
+++ b/src/Snake/Spinner.php
@@ -170,6 +170,10 @@ class Spinner implements SpinnerInterface
     /** @inheritDoc */
     public function setMessage(?string $message): void
     {
+        if ($message === null) {
+            $this->message = null;
+        }
+
         $message = mb_substr($message, 0, $this->terminalCols-10);
         $breakPosition = mb_strpos($message, "\n");
 

--- a/src/Snake/Spinner.php
+++ b/src/Snake/Spinner.php
@@ -102,7 +102,7 @@ class Spinner implements SpinnerInterface
     public function spin(): void
     {
         $message = is_string($this->message) && !empty($this->message)
-            ? ' '.$this->message
+            ? ' ' . $this->message
             : '';
 
         $output =
@@ -125,6 +125,7 @@ class Spinner implements SpinnerInterface
 
     private function update(): void
     {
+        /** @var float $now */
         $now = microtime(true);
         if ($now >= $this->lastFrameTimestamp + $this->interval()) {
             $this->lastFrameTimestamp = $now;
@@ -175,7 +176,7 @@ class Spinner implements SpinnerInterface
             return;
         }
 
-        $message = mb_substr($message, 0, $this->terminalCols-10);
+        $message = mb_substr($message, 0, $this->terminalCols - 10);
         $breakPosition = mb_strpos($message, "\n");
 
         if ($breakPosition !== false) {


### PR DESCRIPTION
**This PR adds support for an optional status message to be displayed along the spinner animation.**

A status message can be set with `Spinner::setMessage('Lorem ipsum')`. An existing status message can be removed with `Spinner::setMessage(null)`. If set, the status message will be output right after the spinner animation, padded by a space character.
Newlines will be removed from the message, it will be trimmed to `current terminal width - 10` characters, leading and trailing whitespace will be trimmed.

This PR closes #3 .